### PR TITLE
Fixes two minor memory leaks.

### DIFF
--- a/Model.cpp
+++ b/Model.cpp
@@ -31,6 +31,7 @@ Minisat::Var Var::gvi = 0;
 
 Model::~Model() {
   if (inits) delete inits;
+  if (sslv) delete sslv;
 }
 
 const Var & Model::primeVar(const Var & v, Minisat::SimpSolver * slv) {

--- a/main.cpp
+++ b/main.cpp
@@ -65,6 +65,7 @@ int main(int argc, char ** argv) {
   }
   // create the Model from the obtained aig
   Model * model = modelFromAiger(aig, propertyIndex);
+  aiger_reset(aig);
   if (!model) return 0;
 
   // model check it


### PR DESCRIPTION
In main.cpp, aiger_reset is called after the model is created from the
aiger file. In Model.cpp, the destructor also frees the allocated
SimpSolver.

Using valgrind before the changes with "$ IC3 < beem/beemadd1b1.aig":

==27667== Memcheck, a memory error detector
==27667== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==27667== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==27667== Command: ./IC3
==27667==
1
==27667==
==27667== HEAP SUMMARY:
==27667==     in use at exit: 336,428 bytes in 2,326 blocks
==27667==   total heap usage: 341,575 allocs, 339,249 frees, 172,697,125 bytes allocated
==27667==
==27667== LEAK SUMMARY:
==27667==    definitely lost: 1,416 bytes in 2 blocks
==27667==    indirectly lost: 335,012 bytes in 2,324 blocks
==27667==      possibly lost: 0 bytes in 0 blocks
==27667==    still reachable: 0 bytes in 0 blocks
==27667==         suppressed: 0 bytes in 0 blocks
==27667== Rerun with --leak-check=full to see details of leaked memory
==27667==
==27667== For counts of detected and suppressed errors, rerun with: -v
==27667== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

after the changes:

==28066== Memcheck, a memory error detector
==28066== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==28066== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info
==28066== Command: ./IC3
==28066==
1
==28066==
==28066== HEAP SUMMARY:
==28066==     in use at exit: 0 bytes in 0 blocks
==28066==   total heap usage: 341,575 allocs, 341,575 frees, 172,697,125 bytes allocated
==28066==
==28066== All heap blocks were freed -- no leaks are possible
==28066==
==28066== For counts of detected and suppressed errors, rerun with: -v
==28066== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)